### PR TITLE
fix: UTF-8 encoding for non ASCII letters

### DIFF
--- a/R/read-utf.R
+++ b/R/read-utf.R
@@ -81,7 +81,7 @@ read_str_raw <- function(con, n) {
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 read_utf8   <- function(con) {
   
-  chars <- integer(0)
+  bytes <- integer(0)
   
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Keep reading bytes until we hit a null terminator
@@ -92,17 +92,17 @@ read_utf8   <- function(con) {
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ch <- read_uint8(con)
   while (ch != 0) {
-    chars <- c(chars, ch)
+    bytes <- c(bytes, ch)
     ch    <- read_uint8(con)
     if (length(ch) == 0) {
       stop("Reached EOF looking for string null terminator")
     }
   }
 
-  res <- intToUtf8(chars)
+  str <- rawToChar(as.raw(bytes))
+  Encoding(str) <- "UTF-8"
   
-  do_eof_check(con, 1, length(res))
-  res
+  str
 }
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/R/write-utf8.R
+++ b/R/write-utf8.R
@@ -48,10 +48,9 @@ write_raw <- function(con, x, bounds_check = NULL) {
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 write_utf8 <- function(con, x) {
-  
   write_utf8_raw(con, x)
   write_uint8(con, 0) # Null terminator
-  
+
   invisible(con)
 }
 
@@ -62,10 +61,11 @@ write_utf8 <- function(con, x) {
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 write_utf8_raw <- function(con, x) {
   stopifnot(is.character(x) && length(x) == 1)
-  
-  bytes <- as.raw(utf8ToInt(x))
-  writeBin(bytes, con)
-  
+
+  xb <- iconv(x, to = "UTF-8")
+
+  writeBin(xb, con)
+
   invisible(con)
 }
 

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -1,0 +1,17 @@
+test_that("utf8 roundtrips work", {
+  input <- 
+    "二項分布\xF0\x9F\x8E\xB2の英語表記は「Binomial distribution」である。"
+  # 二項分布[dice]の英語表記は「Binomial distribution」である。
+ 
+
+  con <- rawConnection(raw(), open = "w")
+  write_utf8(con, input)
+  dat <- rawConnectionValue(con)
+  close(con)
+
+  con <- rawConnection(dat, open = "r")
+  output <- read_utf8(con)
+  close(con)
+
+  expect_equal(output, input, label = paste("roundtrip mismatch: ", "'utf8'"))
+})


### PR DESCRIPTION
Fixed some encoding consistencies when doing UTF-8 IO. I did not convert input from reads to the user R local as R allows you to set an individual encoding on a character vector, if we want we can have a `convert = TRUE` that calls `iconv(from = "UTF-8")`.

Added a test that won't pass under the current code.